### PR TITLE
Atualiza README com instruções de frontend e backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,45 @@ Este projeto é composto por dois módulos principais desenvolvidos em FastAPI:
 1. **Recomendação de Estratégias de Hedge**: Gera estratégias de hedge com base em parâmetros fornecidos.
 2. **Simulação de PnL**: Calcula o PnL com e sem hedge utilizando dados históricos.
 
+Além do backend em FastAPI, agora o repositório contém também um frontend em Next.js na pasta `frontend/`.
+
 ## Requisitos
 - Python 3.10+
 - FastAPI para APIs RESTful
 - Pydantic para validações
+- Node.js e npm para o frontend
 
 ## Estrutura
 ```plaintext
 sistema_hedge/
-├── app/
+├── app/              # Código do backend
 │   ├── main.py
 │   ├── models/
 │   ├── routes/
 │   ├── services/
 │   └── tests/
+├── frontend/         # Projeto Next.js
+└── requirements.txt
 ```
 
 ## Como Rodar
-1. Instale as dependências:
+### Backend
+1. Instale as dependências do Python:
    ```bash
    pip install -r requirements.txt
    ```
-2. Execute o servidor:
+2. Execute o servidor com `uvicorn`:
    ```bash
    uvicorn app.main:app --reload
+   ```
+
+### Frontend
+1. Instale as dependências do projeto React:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Inicie o servidor de desenvolvimento:
+   ```bash
+   npm run dev
    ```


### PR DESCRIPTION
## Summary
- rename README_Version2.md -> README.md
- document new frontend folder
- add backend and frontend setup instructions

## Testing
- `python -m compileall .`

------
https://chatgpt.com/codex/tasks/task_e_68422c5a57f4832e8b6d1458e832b300